### PR TITLE
fix(symbol): use with bootstrap - override reboot style

### DIFF
--- a/projects/ngx-scrolltop/src/lib/ngx-scrolltop.component.scss
+++ b/projects/ngx-scrolltop/src/lib/ngx-scrolltop.component.scss
@@ -34,6 +34,7 @@ button {
     svg {
       transform: translateY(10%); // Centering no-rectangle symbols
       width: $svg-size;
+      vertical-align: baseline;
     }
   }
 


### PR DESCRIPTION
I have found a bug when using with combination with bootstrap. Default reboot.css styles override symbol position. This code should not break anything and override reboot breaks.