### PR TITLE
Performance boost (fix #32)

### DIFF
--- a/projects/ngx-scrolltop/src/lib/ngx-scrolltop.component.spec.ts
+++ b/projects/ngx-scrolltop/src/lib/ngx-scrolltop.component.spec.ts
@@ -1,3 +1,4 @@
+import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NgxScrollTopComponent } from './ngx-scrolltop.component';
 import { NgxScrollTopCoreService } from './ngx-scrolltop.core.service';
@@ -6,6 +7,7 @@ describe('NgxScrollTopComponent', () => {
   let component: NgxScrollTopComponent;
   let fixture: ComponentFixture<NgxScrollTopComponent>;
   let element: HTMLButtonElement;
+  let cdRef: ChangeDetectorRef;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -20,29 +22,31 @@ describe('NgxScrollTopComponent', () => {
     component.show = true;
     fixture.detectChanges();
     element = fixture.nativeElement.querySelector('.scrolltop-button');
+    cdRef = fixture.componentRef.injector.get(ChangeDetectorRef);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
+
   it('should set backgroundColor', () => {
     component.backgroundColor = '#1b5e20';
-    fixture.detectChanges();
+    cdRef.detectChanges();
 
     expect(element.style.backgroundColor).toEqual('rgb(27, 94, 32)');
   });
 
   it('should set backgroundColor with alpha', () => {
     component.backgroundColor = '#212121cc';
-    fixture.detectChanges();
+    cdRef.detectChanges();
 
     expect(element.style.backgroundColor).toEqual('rgba(33, 33, 33, 0.8)');
   });
 
   it('should set symbolColor', () => {
     component.symbolColor = '#FF6F00';
-    fixture.detectChanges();
+    cdRef.detectChanges();
 
     expect(
       fixture.nativeElement.querySelector('.scrolltop-button svg').style.fill
@@ -51,7 +55,7 @@ describe('NgxScrollTopComponent', () => {
 
   it('should set size', () => {
     component.size = 55;
-    fixture.detectChanges();
+    cdRef.detectChanges();
 
     expect(element.style.width).toEqual('55px');
 
@@ -60,14 +64,14 @@ describe('NgxScrollTopComponent', () => {
 
   it('should set position', () => {
     component.position = 'left';
-    fixture.detectChanges();
+    cdRef.detectChanges();
 
     expect(element.style.left).toEqual('20px');
   });
 
   it('should set theme', () => {
     component.theme = 'deeppurple';
-    fixture.detectChanges();
+    cdRef.detectChanges();
 
     const computedStyle = window.getComputedStyle(element);
 

--- a/projects/ngx-scrolltop/src/lib/ngx-scrolltop.component.ts
+++ b/projects/ngx-scrolltop/src/lib/ngx-scrolltop.component.ts
@@ -1,15 +1,24 @@
-import { Component, HostListener, Input, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  HostListener,
+  Input,
+  OnChanges,
+  SimpleChanges
+} from '@angular/core';
 import { NgxScrollTopCoreService } from './ngx-scrolltop.core.service';
 import {
   NgxScrollTopMode,
   NgxScrollTopPosition,
-  NgxScrollTopTheme,
+  NgxScrollTopTheme
 } from './ngx-scrolltop.interface';
 
 @Component({
   selector: 'ngx-scrolltop',
   templateUrl: './ngx-scrolltop.component.html',
   styleUrls: ['./ngx-scrolltop.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NgxScrollTopComponent implements OnChanges {
   @Input() public backgroundColor: string;
@@ -23,11 +32,17 @@ export class NgxScrollTopComponent implements OnChanges {
   public show = false;
 
   @HostListener('window:scroll')
-  public onWindowScroll() {
-    this.show = this.core.onWindowScroll(this.mode);
+  public onWindowScroll(): void {
+    const show = this.core.onWindowScroll(this.mode);
+
+    // Performance boost. Only update the state if it has changed.
+    if (this.show !== show) {
+      this.show = show;
+      this.cdr.markForCheck();
+    }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  public ngOnChanges(changes: SimpleChanges): void {
     // Deprecation warning. It will be removed soon.
     if (changes.symbol) {
       console.error(
@@ -39,7 +54,7 @@ export class NgxScrollTopComponent implements OnChanges {
     }
   }
 
-  constructor(private core: NgxScrollTopCoreService) {}
+  constructor(private core: NgxScrollTopCoreService, private cdr: ChangeDetectorRef) { }
 
   public scrollToTop(): void {
     this.core.scrollToTop();

--- a/projects/ngx-scrolltop/src/lib/ngx-scrolltop.core.service.ts
+++ b/projects/ngx-scrolltop/src/lib/ngx-scrolltop.core.service.ts
@@ -11,32 +11,27 @@ export class NgxScrollTopCoreService {
   constructor(@Inject(DOCUMENT) private document: any) {}
 
   public onWindowScroll(mode: NgxScrollTopMode): boolean {
-    let show = false;
     const position: number =
       this.document.documentElement?.scrollTop || this.document.scrollingElement?.scrollTop;
     switch (mode) {
       case 'classic':
-        show = this.classicMode(position);
-        break;
+        return this.classicMode(position);
       case 'smart':
-        show = this.smartMode(position);
-        break;
+        return this.smartMode(position);
     }
-    return show;
   }
 
   private classicMode(position: number): boolean {
-    let show = false;
     if (this.isBrowser && position > window.innerHeight) {
-      show = true;
+      return true;
     } else {
-      show = false;
+      return false;
     }
-    return show;
   }
 
   private smartMode(position: number): boolean {
     let show = false;
+
     if (position === 0) {
       show = false;
       this.scrolledFromTop = false;

--- a/projects/ngx-scrolltop/src/lib/ngx-scrolltop.directive.spec.ts
+++ b/projects/ngx-scrolltop/src/lib/ngx-scrolltop.directive.spec.ts
@@ -1,18 +1,19 @@
-import { Component } from '@angular/core';
+import { ChangeDetectorRef, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NgxScrollTopDirective } from './ngx-scrolltop.directive';
 import { NgxScrollTopCoreService } from './ngx-scrolltop.core.service';
+import { NgxScrollTopDirective } from './ngx-scrolltop.directive';
 
 @Component({
   template: '<span class="my-scroll-top-button" ngxScrollTop>Top</span>',
 })
 class TestComponent {
-  constructor() {}
+  constructor() { }
 }
 
 describe('NgxScrollTopDirective', () => {
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
+  let cdRef: ChangeDetectorRef;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -22,6 +23,7 @@ describe('NgxScrollTopDirective', () => {
 
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;
+    cdRef = fixture.componentRef.injector.get(ChangeDetectorRef);
   });
 
   it('should create component', () => {
@@ -33,17 +35,19 @@ describe('NgxScrollTopDirective', () => {
     const p: HTMLElement = debugEl.querySelector('.my-scroll-top-button');
 
     // Make window scrollable
-    document.body.style.minHeight = '1000px';
-    window.scrollTo(0, 100);
+    document.body.style.minHeight = '1500px';
+    window.scrollTo(0, 50);
     fixture.detectChanges();
+    cdRef.detectChanges();
 
     p.click();
     fixture.detectChanges();
+    cdRef.detectChanges();
 
     setTimeout(() => {
       // Wait some time for smooth scroll
       expect(document.documentElement.scrollTop).toBe(0);
       done();
-    }, 2000);
+    }, 3000);
   });
 });

--- a/projects/ngx-scrolltop/src/lib/ngx-scrolltop.directive.ts
+++ b/projects/ngx-scrolltop/src/lib/ngx-scrolltop.directive.ts
@@ -8,21 +8,25 @@ import { NgxScrollTopMode } from './ngx-scrolltop.interface';
 export class NgxScrollTopDirective {
   @Input('ngxScrollTopMode') public mode: NgxScrollTopMode = 'classic';
 
+  private show = false;
+
   constructor(private el: ElementRef, private core: NgxScrollTopCoreService) {
     this.hideElement();
   }
 
   @HostListener('window:scroll')
-  public onWindowScroll() {
-    if (this.core.onWindowScroll(this.mode)) {
-      this.showElement();
-    } else {
-      this.hideElement();
+  public onWindowScroll(): void {
+    const show = this.core.onWindowScroll(this.mode);
+
+    // Performance boost. Only update the DOM when the state changes.
+    if (this.show !== show) {
+      show ? this.showElement() : this.hideElement();
+      this.show = show;
     }
   }
 
   @HostListener('click')
-  public onClick() {
+  public onClick(): void {
     this.scrollToTop();
   }
 


### PR DESCRIPTION
Performance boost. (fix #32)
Change detection is now triggered only on the edge between the display and disappearance of the button.